### PR TITLE
fix pip install error for zeep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.22.0
 requests-toolbelt==0.9.1
-zeep=3.4.0
+zeep==3.4.0


### PR DESCRIPTION
Invalid requirement: 'zeep=3.4.0' 
= is not a valid operator. Did you mean == ?