### PR TITLE
Change create_team to return id of newly created team

### DIFF
--- a/CheckmarxPythonSDK/CxRestAPISDK/TeamAPI.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/TeamAPI.py
@@ -109,7 +109,7 @@ class TeamAPI(object):
             parent_id (int): specifies the identifier of the parent team
 
         Returns:
-            None
+            The id of the new team
 
         Raises:
             BadRequestError
@@ -126,8 +126,12 @@ class TeamAPI(object):
             verify=config.get("verify")
         )
         if r.status_code == CREATED:
-            # The create team API does not return a body
-            pass
+            # The create team API returns the location of the new team
+            # in the Location header. E.g.: /cxrestapi/auth/Teams/8
+            location = r.headers['Location']
+            parts = location.split('/')
+            team_id = int(parts[-1])
+            return team_id
         elif r.status_code == BAD_REQUEST:
             raise BadRequestError(r.text)
         elif (r.status_code == UNAUTHORIZED) and (self.retry < config.get("max_try")):


### PR DESCRIPTION
I didn't read the REST API documentation closely enough: the POST /teams API returns the location of the new team, which includes its id, in the "Location" header.