### PR TITLE
Fix the get_user_entries_by_search_criteria AccessControl method.

### DIFF
--- a/CheckmarxPythonSDK/CxAccessControl/AccessControl.py
+++ b/CheckmarxPythonSDK/CxAccessControl/AccessControl.py
@@ -280,7 +280,14 @@ class AccessControl:
         response = self.get_request(relative_url=relative_url)
         if response.status_code == OK:
             result = [
-                construct_user(item) for item in response.json()
+                # We can't use construct_user because the response
+                # property names are slightly different (e.g.,
+                # "firstname" instead of "firstName".
+                User(email=item["email"],
+                     first_name=item["firstname"],
+                     last_name=item["lastname"],
+                     username=item["username"]
+                     ) for item in response.json()
             ]
         return result
 


### PR DESCRIPTION
The property names in the response to the `GET /LDAPServers/{id}/UserEntries` endpoint are slightly different to those returned by other user retrieval methods. This means that we cannot use the `construct_user` function. For example, "firstname" versus "firstName".

As an LDAP user must have email, first name, last name and username, we use the `[]` operator instead of the `get` method.