### PR TITLE
Add support for the /serverLicenseData endpoint

### DIFF
--- a/CheckmarxPythonSDK/CxRestAPISDK/GeneralAPI.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/GeneralAPI.py
@@ -1,0 +1,43 @@
+# encoding: utf-8
+import json
+from .httpRequests import get_request, put_request, get_headers
+from CheckmarxPythonSDK.utilities.compat import OK
+from .sast.configuration.dto import CxSASTConfig
+from .sast.general.dto import CxServerLicenseData, CxSupportedLanguage
+
+class GeneralAPI:
+    """
+    CxSAST general API
+    """
+    @staticmethod
+    def get_server_license_data(api_version="4.0"):
+        """
+        Returns the CxSAST server's license data
+        """
+        result = None
+        relative_url = "/cxrestapi/serverLicenseData"
+        response = get_request(relative_url=relative_url, headers=get_headers(api_version))
+        if response.status_code == OK:
+            json = response.json()
+            result = CxServerLicenseData(
+                current_audit_users = json["currentAuditUsers"],
+                current_projects_count = json["currentProjectsCount"],
+                current_users = json["currentUsers"],
+                edition = json["edition"],
+                expiration_date = json["expirationDate"],
+                hid = json["hid"],
+                is_osa_enabled = json["isOsaEnabled"],
+                max_audit_users = json["maxAuditUsers"],
+                max_concurrent_scans = json["maxConcurrentScans"],
+                max_loc = json["maxLOC"],
+                max_users = json["maxUsers"],
+                osa_expiration_date = json["osaExpirationDate"],
+                projects_allowed = json["projectsAllowed"],
+                supported_languages = [
+                    CxSupportedLanguage(
+                        is_supported = item["isSupported"],
+                        language = item["language"])
+                    for item in json["supportedLanguages"]
+                    ]
+                )
+        return result

--- a/CheckmarxPythonSDK/CxRestAPISDK/__init__.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/__init__.py
@@ -19,3 +19,4 @@ from .OsaAPI import OsaAPI
 from .ConfigurationAPI import ConfigurationAPI
 from .QueriesAPI import QueriesAPI
 from .AccessControlAPI import AccessControlAPI
+from .GeneralAPI import GeneralAPI

--- a/CheckmarxPythonSDK/CxRestAPISDK/sast/general/dto/CxServerLicenseData.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/sast/general/dto/CxServerLicenseData.py
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+import datetime
+import logging
+
+class CxServerLicenseData(object):
+    """
+    CxSAST server license data
+    """
+    def __init__(self, current_audit_users, current_projects_count,
+                 current_users, edition, expiration_date, hid, is_osa_enabled,
+                 max_audit_users, max_concurrent_scans, max_loc, max_users,
+                 osa_expiration_date, projects_allowed, supported_languages):
+        self.current_audit_users = current_audit_users
+        self.current_projects_count = current_projects_count
+        self.current_users = current_users
+        self.edition = edition
+        self.expiration_date = parse_expiration_date(expiration_date)
+        self.hid = hid
+        self.is_osa_enabled = is_osa_enabled
+        self.max_audit_users = max_audit_users
+        self.max_concurrent_scans = max_concurrent_scans
+        self.max_loc = max_loc
+        self.max_users = max_users
+        # If there is no OSA expiration date, an empty string is returned.
+        # We coerce it to None
+        if not osa_expiration_date:
+            self.osa_expiration_date = None
+        else:
+            self.osa_expiration_date = parse_expiration_date(osa_expiration_date)
+        self.projects_allowed = projects_allowed
+        self.supported_languages = supported_languages
+
+    def __str__(self):
+        return """CxServerLicenseData(current_audit_users={},
+               current_projects_count={}, current_users={}, edition={},
+               expiration_date={}, hid={}, is_osa_enabled={},
+               max_audit_users={}, max_concurrent_scans={}, max_loc={}
+               max_users={}, osa_expiration_date={},
+               projects_allowed={}, supported_languages={})""".format(
+                   self.current_audit_users, self.current_projects_count,
+                   self.current_users, self.edition, self.expiration_date,
+                   self.hid, self.is_osa_enabled, self.max_audit_users,
+                   self.max_concurrent_scans, self.max_loc, self.max_users,
+                   self.osa_expiration_date, self.projects_allowed,
+                   self.supported_languages
+               )
+
+def parse_expiration_date(date_str):
+    """
+    Parse a date string in MM/DD/YYYY format into a datetime.date object. If
+    the string cannot be parsed, we return it instead.
+    """
+    bits = date_str.split('/')
+    try:
+        return datetime.date(int(bits[2]), int(bits[0]), int(bits[1]))
+    except:
+        logger.debug("Cannot parse {} as MM/DD/YYYY".format(date_str))
+        return date_str

--- a/CheckmarxPythonSDK/CxRestAPISDK/sast/general/dto/CxSupportedLanguage.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/sast/general/dto/CxSupportedLanguage.py
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+class CxSupportedLanguage(object):
+    """
+    The support status of a given programming language
+    """
+    def __init__(self, is_supported, language):
+        self.is_supported = is_supported
+        self.language = language
+
+    def __str__(self):
+        return """CxSupportedLanguage(is_supported={}, language={})""".format(
+            self.is_supported, self.language
+        )

--- a/CheckmarxPythonSDK/CxRestAPISDK/sast/general/dto/__init__.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/sast/general/dto/__init__.py
@@ -1,0 +1,2 @@
+from .CxServerLicenseData import CxServerLicenseData
+from .CxSupportedLanguage import CxSupportedLanguage


### PR DESCRIPTION
Add support for the /serviceLicenseData endpoint, added in version 4.0 of the CxSAST REST API. This endpoint returns the license details of the CxSAST instance.