### PR TITLE
fix import error on get_a_list_of_scans

### DIFF
--- a/CheckmarxPythonSDK/CxOne/__init__.py
+++ b/CheckmarxPythonSDK/CxOne/__init__.py
@@ -106,6 +106,7 @@ from .sastResultsAPI import (
 from .scansAPI import (
     create_scan,
     get_a_list_of_scan,
+    get_a_list_of_scans,
     get_all_scan_tags,
     get_summary_of_the_status_of_the_scans,
     get_the_list_of_available_config_as_code_template_files,


### PR DESCRIPTION
`get_a_list_of_scan` is deprecated and the reason is telling to use `get_a_list_of_scans` instead, however `get_a_list_of_scans` cannot be imported

to reproduce:

```
from CheckmarxPythonSDK.CxOne import (
    get_a_list_of_scans,
)
```