### PR TITLE
Added functions for add repo url, add tokens, generate SCA risk report

### DIFF
--- a/CheckmarxPythonSDK/CxOne/__init__.py
+++ b/CheckmarxPythonSDK/CxOne/__init__.py
@@ -88,6 +88,9 @@ from .scanConfigurationAPI import (
     get_sast_default_config_by_id,
     update_default_config_for_the_sast_engine,
     delete_a_sast_default_config,
+    update_project_repo_url,
+    update_project_token
+
 )
 
 from .scannersResultsAPI import (

--- a/CheckmarxPythonSDK/CxOne/reportAPI.py
+++ b/CheckmarxPythonSDK/CxOne/reportAPI.py
@@ -61,3 +61,9 @@ def get_scan_report(report_id):
 
     response = get_request(relative_url=relative_url)
     return response.content
+
+def get_risk_scan_report(scan_id, report_type):
+    relative_url = f"/api/sca/risk-management/risk-reports/{scan_id}/export?format={report_type}"
+    
+    response = get_request(relative_url=relative_url)
+    return response.content

--- a/CheckmarxPythonSDK/CxOne/scanConfigurationAPI.py
+++ b/CheckmarxPythonSDK/CxOne/scanConfigurationAPI.py
@@ -236,3 +236,65 @@ def delete_a_sast_default_config(config_id):
     if response.status_code == NO_CONTENT:
         result = True
     return result
+
+
+def update_project_repo_url(project_id, repo_url):
+    """
+
+    Args:
+        project_id (str):
+        repo_url (str):
+
+    Returns:
+
+    """
+    type_check(project_id, str)
+    type_check(repo_url, str)
+    relative_url = api_url + "/project?project-id=" + project_id
+    data=[{
+            "key": "scan.handler.git.repository",
+            "name": "repository",
+            "category": "git",
+            "originLevel": "Project",
+            "value": repo_url,
+            "valuetype": "String",
+            "allowOverride": True
+        }]
+
+    data_json = json.dumps(data)  
+    response = patch_request(relative_url=relative_url, data=data_json)
+
+    if response.status_code == NO_CONTENT:
+        result = True
+    return result
+
+
+def update_project_token(project_id, token):
+    """
+
+    Args:
+        project_id (str):
+        token (str):
+
+    Returns:
+
+    """
+    type_check(project_id, str)
+    type_check(token, str)
+    relative_url = api_url + "/project?project-id=" + project_id
+    data=[{
+        	"key": "scan.handler.git.token",
+        	"name": "token",
+        	"category": "git",
+        	"originLevel": "Project",
+        	"value": token,
+        	"valuetype": "Secret",
+        	"allowOverride": True
+        },]
+
+    data_json = json.dumps(data)  
+    response = patch_request(relative_url=relative_url, data=data_json)
+
+    if response.status_code == NO_CONTENT:
+        result = True
+    return result


### PR DESCRIPTION
I've added threes functions to add a repo URL and add tokens (e.g. API keys) and get sca risk report. You can easily test with something like this, and then verify in the UI:

```
import json

from CheckmarxPythonSDK.CxOne import (
    update_project_repo_url,
    update_project_token
)

r = update_project_token("REPLACE_WITH_PROJECT_ID", "REPLACE_WITH_API_KEY")
print(r)
...
```