### PR TITLE
Add support for the feature flags API

### DIFF
--- a/CheckmarxPythonSDK/CxOne/__init__.py
+++ b/CheckmarxPythonSDK/CxOne/__init__.py
@@ -14,6 +14,11 @@ from .applicationsAPI import (
     delete_an_application_rule,
 )
 
+from .flagsAPI import (
+    get_all_feature_flags,
+    get_feature_flag,
+)
+
 from .healthCheckServiceAPI import (
     get_health_of_the_database,
     get_health_of_the_in_memory_db,

--- a/CheckmarxPythonSDK/CxOne/dto/Flag.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Flag.py
@@ -1,0 +1,18 @@
+# encoding utf-8
+class Flag(object):
+    def __init__(self, name, status, payload):
+        """
+
+        Args:
+            name (str)
+            status (boolean)
+            payload (dict)
+        """
+        self.name = name
+        self.status = status
+        self.payload = payload
+
+    def __str__(self):
+        return """Flag(name={name}, status={status}, payload={payload}""".format(
+            name=self.name, status=self.status, payload=self.payload
+        )

--- a/CheckmarxPythonSDK/CxOne/dto/__init__.py
+++ b/CheckmarxPythonSDK/CxOne/dto/__init__.py
@@ -9,6 +9,7 @@ from .DefaultConfig import DefaultConfig
 from .DefaultConfigOut import DefaultConfigOut
 from .Error import Error
 from .FileInfo import FileInfo
+from .Flag import Flag
 from .Git import Git
 from .Group import Group
 from .KicsResult import KicsResult

--- a/CheckmarxPythonSDK/CxOne/flagsAPI.py
+++ b/CheckmarxPythonSDK/CxOne/flagsAPI.py
@@ -1,0 +1,50 @@
+# encoding: utf-8
+import json
+import requests
+import time
+import os
+from CheckmarxPythonSDK.CxOne.httpRequests import get_request, post_request
+from CheckmarxPythonSDK.CxOne import authHeaders
+from CheckmarxPythonSDK.CxOne.config import config
+from .dto import (
+    Flag,
+)
+
+base_url = config.get("server")
+
+def __construct_flag(flag):
+    return Flag(
+        name=flag.get("name"),
+        status=flag.get("status"),
+        payload=flag.get("payload")
+    )
+
+def get_all_feature_flags():
+    """
+
+    Returns:
+        `list` of `Flag`
+    """
+    relative_url = f"/api/flags/"
+
+    response = get_request(relative_url=relative_url)
+
+    flags = response.json()
+    return [__construct_flag(flag) for flag in flags]
+
+
+def get_feature_flag(name):
+    """
+
+    Args:
+        name (`str`)
+
+    Returns:
+        `Flag`
+    """
+    relative_url = f"/api/flags/{name}"
+
+    response = get_request(relative_url=relative_url)
+
+    flag = response.json()
+    return __construct_flag(flag)

--- a/CheckmarxPythonSDK/CxOne/flagsAPI.py
+++ b/CheckmarxPythonSDK/CxOne/flagsAPI.py
@@ -4,7 +4,6 @@ import requests
 import time
 import os
 from CheckmarxPythonSDK.CxOne.httpRequests import get_request, post_request
-from CheckmarxPythonSDK.CxOne import authHeaders
 from CheckmarxPythonSDK.CxOne.config import config
 from .dto import (
     Flag,


### PR DESCRIPTION
This PR adds support for the Checkmarx One feature flags API (see https://ast.checkmarx.net/spec/v1/?urls.primaryName=Feature%20Flag). Two functions are added:

* `get_all_feature_flags`: retrieves all the feature flags
* `get_feature_flag`: retrieves the named feature flag