### PR TITLE
Fixes to the CxOne flags API

### DIFF
--- a/CheckmarxPythonSDK/CxOne/config.py
+++ b/CheckmarxPythonSDK/CxOne/config.py
@@ -6,6 +6,7 @@ from CheckmarxPythonSDK.utilities.configUtility import (
 config_default = {
     "access_control_url": "https://iam.checkmarx.net",
     "server": "https://ast.checkmarx.net",
+    "tenant_id": None, # Needed for the feature flags API (see flagsAPI.py)
     "tenant_name": None,
     "grant_type": "refresh_token",
     "client_id": "ast-app",

--- a/CheckmarxPythonSDK/CxOne/dto/Flag.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Flag.py
@@ -13,6 +13,6 @@ class Flag(object):
         self.payload = payload
 
     def __str__(self):
-        return """Flag(name={name}, status={status}, payload={payload}""".format(
+        return """Flag(name={name}, status={status}, payload={payload})""".format(
             name=self.name, status=self.status, payload=self.payload
         )

--- a/CheckmarxPythonSDK/CxOne/flagsAPI.py
+++ b/CheckmarxPythonSDK/CxOne/flagsAPI.py
@@ -28,7 +28,10 @@ def get_all_feature_flags():
     Returns:
         `list` of `Flag`
     """
-    relative_url = api_url
+    if not config['tenant_id']:
+        _set_tenant_id()
+
+    relative_url = f"{api_url}?filter={config['tenant_id']}"
 
     response = get_request(relative_url=relative_url)
 
@@ -45,9 +48,19 @@ def get_feature_flag(name):
     Returns:
         `Flag`
     """
-    relative_url = api_url + f"/{name}"
+    if not config['tenant_id']:
+        _set_tenant_id()
+
+    relative_url = f"{api_url}{name}?filter={config['tenant_id']}"
 
     response = get_request(relative_url=relative_url)
 
     flag = response.json()
     return __construct_flag(flag)
+
+
+def _set_tenant_id():
+
+    resp = get_request(f"/auth/admin/realms/{config['tenant_name']}",
+                       is_iam=True)
+    config['tenant_id'] = resp.json()['id']


### PR DESCRIPTION
This pull requests addresses two problems with the `flagsAPI` module:

- The string representation of a feature flag was missing a closing parenthesis.
- The API requires that the caller provide a `filter` query parameter whose value is the tenant id. As the tenant id is not in the SDK's default configuration, we retrieve it (using the Keycloak API) the first time one of the feature flag functions is used.