### PR TITLE
Update httpRequests.py

### DIFF
--- a/CheckmarxPythonSDK/utilities/httpRequests.py
+++ b/CheckmarxPythonSDK/utilities/httpRequests.py
@@ -354,7 +354,7 @@ def check_response(response):
     text = response.text
     if True in [
         method in ['GET', 'HEAD'] and status_code not in [OK, UNAUTHORIZED],
-        method == 'POST' and status_code not in [OK, CREATED, UNAUTHORIZED, ACCEPTED],
+        method == 'POST' and status_code not in [OK, NO_CONTENT, CREATED, UNAUTHORIZED, ACCEPTED],
         method in ['PUT', 'PATCH', 'DELETE'] and status_code not in [OK, NO_CONTENT, ACCEPTED, UNAUTHORIZED],
     ]:
         raise ValueError("HttpStatusCode: {code}".format(code=status_code),


### PR DESCRIPTION
Small fix, added in NO_CONTENT in check_response(). Although, perhaps need to rework `check_response()` to only look for 401 unauthorized because CxOne is quite inconsistent with how data is added e.g. POST when adding user role, and then PUT for adding groups, and then combining the various status code it responds too.

As to where this POST NO CONTENT is used, there are functionalities in IAM when modifying a user's role mappings. It will use POST `/auth/admin/realms/{realm}/users/{user_id}/role-mappings/clients/{role_id}` when you add a new role to the user. The response is 204 No Content. 