### PR TITLE
Update wrapper for new flags API

### DIFF
--- a/CheckmarxPythonSDK/CxOne/config.py
+++ b/CheckmarxPythonSDK/CxOne/config.py
@@ -6,7 +6,6 @@ from CheckmarxPythonSDK.utilities.configUtility import (
 config_default = {
     "access_control_url": "https://iam.checkmarx.net",
     "server": "https://ast.checkmarx.net",
-    "tenant_id": None, # Needed for the feature flags API (see flagsAPI.py)
     "tenant_name": None,
     "grant_type": "refresh_token",
     "client_id": "ast-app",

--- a/CheckmarxPythonSDK/CxOne/dto/Flag.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Flag.py
@@ -12,6 +12,16 @@ class Flag(object):
         self.status = status
         self.payload = payload
 
+    def __eq__(self, other):
+
+        return (self.name == other.name and
+                self.status == other.status and
+                self.payload == other.payload)
+
+    def __lt__(self, other):
+
+        return self.name < other.name
+
     def __str__(self):
         return """Flag(name={name}, status={status}, payload={payload})""".format(
             name=self.name, status=self.status, payload=self.payload

--- a/tests/CxOne/test_flags_api.py
+++ b/tests/CxOne/test_flags_api.py
@@ -1,0 +1,44 @@
+from CheckmarxPythonSDK.CxOne import (
+    get_all_feature_flags,
+    get_feature_flag
+)
+
+def test_get_all_feature_flags_no_args():
+
+    flags = get_all_feature_flags()
+    assert flags is not None
+    assert type(flags) is list
+
+
+def test_get_all_feature_flags_one_flag():
+
+    # This flag should be enabled in all tenants
+    flags = get_all_feature_flags(["SBOM_SCAN_ENABLED"])
+    assert flags is not None
+    assert type(flags) is list
+    assert len(flags) == 1
+    assert flags[0].name == "SBOM_SCAN_ENABLED"
+    assert flags[0].status
+
+
+def test_get_all_feature_flags_two_flags():
+
+    # These flags should be enabled in all tenants
+    flags = get_all_feature_flags(["NEW_PROJECT_REPORT_ENABLED", "SBOM_SCAN_ENABLED"])
+    assert flags is not None
+    assert type(flags) is list
+    assert len(flags) == 2
+    flags = sorted(flags)
+    assert flags[0].name == "NEW_PROJECT_REPORT_ENABLED"
+    assert flags[0].status
+    assert flags[1].name == "SBOM_SCAN_ENABLED"
+    assert flags[1].status
+
+
+def test_get_feature_flag():
+
+    # This flag should be enabled in all tenants
+    flag = get_feature_flag("SBOM_SCAN_ENABLED")
+    assert flag is not None
+    assert flag.name == "SBOM_SCAN_ENABLED"
+    assert flag.status


### PR DESCRIPTION
The Checkmarx One feature flags API has been updated. It is no longer necessary to pass the tenant id as a query parameter. Also, the endpoint for retrieving all feature flags now accepts a list of flags to retrieve.

I have also added an initial unit test file.