### PR TITLE
Remove stray print statement.

### DIFF
--- a/CheckmarxPythonSDK/CxOne/flagsAPI.py
+++ b/CheckmarxPythonSDK/CxOne/flagsAPI.py
@@ -41,7 +41,6 @@ def get_all_feature_flags(ids=None):
     if ids:
         relative_url += f"?ids={','.join(ids)}"
 
-    print(f'relative_url: {relative_url}')
     response = get_request(relative_url=relative_url)
 
     flags = response.json()


### PR DESCRIPTION
Remove a debugging print statement left behind after the reworking of the wrapper for the feature flags API.