### PR TITLE
Updated for customers, readability, and dates in statusDetails

### DIFF
--- a/CheckmarxPythonSDK/CxOne/dto/Scan.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Scan.py
@@ -2,7 +2,7 @@
 from CheckmarxPythonSDK.CxOne import projectsAPI
 class Scan(object):
     def __init__(self, scan_id, status, status_details, position_in_queue, project_id, branch, commit_id, commit_tag,
-                 upload_url, created_at, updated_at, user_agent, initiator, tags, metadata):
+                 upload_url, created_at, updated_at, user_agent, initiator, tags, metadata,source_type, source_origin):
         """
 
         Args:
@@ -38,12 +38,14 @@ class Scan(object):
         self.initiator = initiator
         self.tags = tags
         self.metadata = metadata
+        self.sourceType = source_type
+        self.sourceOrigin = source_origin
         self.project_name = self.get_project_name() or None
 
     def __str__(self):
         return """Scan(id={}, status={}, statusDetails={}, positionInQueue={}, projectId={}, branch={}, commitId={},
         commitTag={}, uploadUrl={}, createdAt={}, updatedAt={}, userAgent={}, initiator={}, tags={}, 
-        metadata={})""".format(
+        metadata={}, sourceType={},sourceOrigin={})""".format(
             self.id,
             self.status,
             self.statusDetails,
@@ -59,6 +61,8 @@ class Scan(object):
             self.initiator,
             self.tags,
             self.metadata,
+            self.sourceType,
+            self.sourceOrigin
         )
 
     def get_project_name(self):

--- a/CheckmarxPythonSDK/CxOne/dto/Scan.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Scan.py
@@ -22,10 +22,16 @@ class Scan(object):
             initiator (str): An identifier of the user who created the scan.
             tags (dict): An object representing the scan tags in a key-value format
             metadata (dict): A JSON object containing info about the scan settings.
+            source_type (str): The type of source of the scan.
+            source_origin (str): The origin of the scan.
+            project_name (str): The name of the project.
         """
-        self.id = scan_id
+        self.scan_id = scan_id
         self.status = status
-        self.statusDetails = status_details
+        self.status_details = status_details
+        self.position_in_queue = position_in_queue
+        self.project_id = project_id
+        self.branch = branch
         self.positionInQueue = position_in_queue
         self.projectId = project_id
         self.branch = branch
@@ -40,12 +46,12 @@ class Scan(object):
         self.metadata = metadata
         self.sourceType = source_type
         self.sourceOrigin = source_origin
-        self.project_name = self.get_project_name() or None
+        self.project_name = self.get_project_name() or ""
 
     def __str__(self):
         return """Scan(id={}, status={}, statusDetails={}, positionInQueue={}, projectId={}, branch={}, commitId={},
         commitTag={}, uploadUrl={}, createdAt={}, updatedAt={}, userAgent={}, initiator={}, tags={}, 
-        metadata={}, sourceType={},sourceOrigin={})""".format(
+        metadata={}, sourceType={},sourceOrigin={}, project_name={})""".format(
             self.id,
             self.status,
             self.statusDetails,
@@ -62,7 +68,8 @@ class Scan(object):
             self.tags,
             self.metadata,
             self.sourceType,
-            self.sourceOrigin
+            self.sourceOrigin,
+            self.project_name
         )
 
     def get_project_name(self):

--- a/CheckmarxPythonSDK/CxOne/dto/Scan.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Scan.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from CheckmarxPythonSDK.CxOne import projectsAPI
 class Scan(object):
     def __init__(self, scan_id, status, status_details, position_in_queue, project_id, branch, commit_id, commit_tag,
                  upload_url, created_at, updated_at, user_agent, initiator, tags, metadata):
@@ -37,6 +38,7 @@ class Scan(object):
         self.initiator = initiator
         self.tags = tags
         self.metadata = metadata
+        self.project_name = self.get_project_name() or None
 
     def __str__(self):
         return """Scan(id={}, status={}, statusDetails={}, positionInQueue={}, projectId={}, branch={}, commitId={},
@@ -58,3 +60,6 @@ class Scan(object):
             self.tags,
             self.metadata,
         )
+
+    def get_project_name(self):
+        return projectsAPI.get_a_project_by_id(self.projectId).name

--- a/CheckmarxPythonSDK/CxOne/dto/StatusDetails.py
+++ b/CheckmarxPythonSDK/CxOne/dto/StatusDetails.py
@@ -7,6 +7,8 @@ class StatusDetails(object):
             name:
             status:
             details:
+            start_date:
+            end_date:
         """
         self.name = name
         self.status = status
@@ -16,7 +18,7 @@ class StatusDetails(object):
 
     def __str__(self):
         return """StatusDetails(name={}, status={}, details={}, start_date={},end_date={})""".format(
-            self.name, self.status, self.details
+            self.name, self.status, self.details, self.start_date, self.end_date
         )
 
     def as_dict(self):

--- a/CheckmarxPythonSDK/CxOne/dto/StatusDetails.py
+++ b/CheckmarxPythonSDK/CxOne/dto/StatusDetails.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 class StatusDetails(object):
-    def __init__(self, name, status, details):
+    def __init__(self, name, status, details, start_date, end_date):
         """
 
         Args:
@@ -11,9 +11,11 @@ class StatusDetails(object):
         self.name = name
         self.status = status
         self.details = details
+        self.start_date = start_date
+        self.end_date = end_date
 
     def __str__(self):
-        return """StatusDetails(name={}, status={}, details={})""".format(
+        return """StatusDetails(name={}, status={}, details={}, start_date={},end_date={})""".format(
             self.name, self.status, self.details
         )
 
@@ -21,5 +23,7 @@ class StatusDetails(object):
         return {
             "name": self.name,
             "status": self.status,
-            "details": self.details
+            "details": self.details,
+            "start_date": self.start_date,
+            "end_date": self.end_date
         }

--- a/CheckmarxPythonSDK/CxOne/scansAPI.py
+++ b/CheckmarxPythonSDK/CxOne/scansAPI.py
@@ -26,6 +26,8 @@ def __construct_scan(item):
                 name=detail.get("name"),
                 status=detail.get("status"),
                 details=detail.get("details"),
+                start_date = detail.get("startDate"),
+                end_date = detail.get("endDate")
             )
             for detail in item.get("statusDetails") or []
         ],
@@ -42,7 +44,6 @@ def __construct_scan(item):
         tags=item.get("tags"),
         metadata=item.get("metadata"),
     )
-
 
 def create_scan(scan_input):
     """

--- a/CheckmarxPythonSDK/CxOne/scansAPI.py
+++ b/CheckmarxPythonSDK/CxOne/scansAPI.py
@@ -43,6 +43,8 @@ def __construct_scan(item):
         initiator=item.get("initiator"),
         tags=item.get("tags"),
         metadata=item.get("metadata"),
+        source_type = item.get("sourceType"),
+        source_origin = item.get("sourceOrigin")
     )
 
 def create_scan(scan_input):


### PR DESCRIPTION
Working with end users -- here are some updates that may be of value.

1. Updated Scan fields for less ambiguity (id->scan_id) and added fields that users have mentioned would be of value in the results. (source_type, source_origin, porject_name). Added the project name as well instead of ID only for readability leveraging the a new method in Scan.py. method: get_project_name()
2.  In the StatusDetails, I noticed there was no start_date and end_date for the scan so I updated that constructor to include those values. Those values were already being returned in the get_a_list_of_scans() response variable but there was no way to access them. So now in the status details we can see when the specific scan was started and ended. This is something that has been requested by end users. 