### PR TITLE
Fix infinite loop in the zeepClient retry_when_unauthorized decorator

### DIFF
--- a/CheckmarxPythonSDK/CxPortalSoapApiSDK/zeepClient.py
+++ b/CheckmarxPythonSDK/CxPortalSoapApiSDK/zeepClient.py
@@ -30,6 +30,7 @@ def retry_when_unauthorized(max_retries: int = 1):
                          or '12563' in response.ErrorMessage
                          or 'Invalid_Token' in response.ErrorMessage):
                     self.token_manager.refresh_token()
+                retries += 1
             raise Exception("Max retries exceeded")
 
         return wrapper


### PR DESCRIPTION
The `decorator` function of the `retry_when_unauthorized` decorator did not increment the value of the `retries` variable. Now it does, preventing an infinite loop.