### PR TITLE
Import the SOAP version of construct_configuration()

### DIFF
--- a/CheckmarxPythonSDK/CxPortalSoapApiSDK/CxAuditWebService.py
+++ b/CheckmarxPythonSDK/CxPortalSoapApiSDK/CxAuditWebService.py
@@ -1,5 +1,5 @@
 from CheckmarxPythonSDK.configuration import Configuration
-from CheckmarxPythonSDK.CxRestAPISDK.config import construct_configuration
+from CheckmarxPythonSDK.CxPortalSoapApiSDK.config import construct_configuration
 from .zeepClient import ZeepClient
 
 

--- a/CheckmarxPythonSDK/CxPortalSoapApiSDK/CxPortalWebService.py
+++ b/CheckmarxPythonSDK/CxPortalSoapApiSDK/CxPortalWebService.py
@@ -7,7 +7,7 @@
 from os.path import exists
 from typing import List
 from CheckmarxPythonSDK.configuration import Configuration
-from CheckmarxPythonSDK.CxRestAPISDK.config import construct_configuration
+from CheckmarxPythonSDK.CxPortalSoapApiSDK.config import construct_configuration
 from .zeepClient import ZeepClient
 
 


### PR DESCRIPTION
The SOAP code previously imported the REST version of the `construct_configuration()` function causing it to use the wrong values for the `scope` and `client_id` properties of the authentication request. It now imports the SOAP version of this function.