### PR TITLE
Fix DTO null rules parsing and field mapping

### DIFF
--- a/CheckmarxPythonSDK/CxOne/accessManagementAPI.py
+++ b/CheckmarxPythonSDK/CxOne/accessManagementAPI.py
@@ -19,7 +19,7 @@ from .dto import (
     EntityRolesRequest,
     CreateRoleRequest,
     GroupsResponse, construct_groups_response,
-    Group,
+    Group, construct_group,
     User, construct_user,
     Client, construct_client,
     construct_internal_user,
@@ -526,7 +526,7 @@ class AccessManagementAPI(object):
         relative_url = f"{api_url}/groups"
         params = {"limit": limit, "offset": offset, "search": search, "ids": ",".join(ids)}
         response = self.api_client.get_request(relative_url=relative_url, params=params)
-        return [construct_groups_response(group) for group in response.json()]
+        return [construct_group(group) for group in response.json()]
 
     def retrieve_users(
             self, limit: int = None, offset: int = None, search: str = None

--- a/CheckmarxPythonSDK/CxOne/dto/Application.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Application.py
@@ -23,7 +23,7 @@ def construct_application(item):
         description=item.get("description"),
         criticality=item.get("criticality"),
         rules=[
-            construct_rule(rule) for rule in item.get("rules", [])
+            construct_rule(rule) for rule in (item.get("rules") or [])
         ],
         project_ids=item.get("projectIds"),
         created_at=item.get("createdAt"),

--- a/CheckmarxPythonSDK/CxOne/dto/CreatedApplication.py
+++ b/CheckmarxPythonSDK/CxOne/dto/CreatedApplication.py
@@ -35,7 +35,7 @@ def construct_created_application(item):
         description=item.get("description"),
         criticality=item.get("criticality"),
         rules=[
-            construct_rule(rule) for rule in item.get("rules", [])
+            construct_rule(rule) for rule in (item.get("rules") or [])
         ],
         tags=item.get("tags"),
         created_at=item.get("createdAt"),

--- a/CheckmarxPythonSDK/CxOne/dto/RichProject.py
+++ b/CheckmarxPythonSDK/CxOne/dto/RichProject.py
@@ -39,6 +39,8 @@ class RichProject:
             default: 3
             example: 3
             Criticality level of the project
+        repo_id (int): The id of the repository
+        scm_repo_id (str): The SCM repository id
     """
 
     id: str
@@ -51,8 +53,9 @@ class RichProject:
     created_at: str = None
     updated_at: str = None
     tags: dict = None
-    criticality: int = 3,
-
+    criticality: int = 3
+    repo_id: int = None
+    scm_repo_id: str = None
 
 def construct_rich_project(item):
     return RichProject(
@@ -66,5 +69,7 @@ def construct_rich_project(item):
         created_at=item.get("createdAt"),
         updated_at=item.get("updatedAt"),
         tags=item.get("tags"),
-        criticality=item.get("criticality")
+        criticality=item.get("criticality"),
+        repo_id=item.get("repoId"),
+        scm_repo_id=item.get("scmRepoId")
     )

--- a/CheckmarxPythonSDK/api_client.py
+++ b/CheckmarxPythonSDK/api_client.py
@@ -194,7 +194,7 @@ class ApiClient(object):
             http_fqdn_list = self.configuration.token_url.split("/")[0:3]
             http_fqdn_list.pop(1)
             access_control_url = "//".join(http_fqdn_list)
-            url = access_control_url + relative_url
+            url = access_control_url.rstrip('/') + '/' + relative_url.lstrip('/')
         return url
 
     @retry_when_unauthorized(max_retries=2)


### PR DESCRIPTION
**1. Fix null rules handling in Application DTOs**
Create application without rules will return `Null` rule
<img width="413" height="229" alt="image" src="https://github.com/user-attachments/assets/e397cf89-334b-430d-802c-d40562b623eb" />

**2. Add missing `repo_id` and `scm_repo_id` fields to RichProject**


**3. Standardize URL path concatenation**
Fixed inconsistent slash handling that caused malformed URLs.

**4. Fix retrieve_groups() to use group constructor**
Changes `construct_groups_response()` to `construct_group()` to properly handle individual group objects from API response
