### PR TITLE
Add the get_warnings_of_a_scan method (SCA)

### DIFF
--- a/CheckmarxPythonSDK/CxScaApiSDK/__init__.py
+++ b/CheckmarxPythonSDK/CxScaApiSDK/__init__.py
@@ -15,6 +15,7 @@ from .api import (
     get_packages_of_a_scan,
     get_vulnerabilities_of_a_scan,
     get_licenses_of_a_scan,
+    get_warnings_of_a_scan,
     ignore_a_vulnerability_for_a_specific_package_and_project,
     undo_the_ignore_state_of_an_ignored_vulnerability,
     get_settings_for_a_specific_project,

--- a/CheckmarxPythonSDK/CxScaApiSDK/api.py
+++ b/CheckmarxPythonSDK/CxScaApiSDK/api.py
@@ -693,6 +693,29 @@ class Sca(object):
         response = self.api_client.get_request(relative_url=url)
         return response.json()
 
+    def get_warnings_of_a_scan(self, scan_id: str) -> List[dict]:
+        """
+
+        Args:
+            scan_id (str):
+
+        Returns:
+            list of dict
+
+            sample:
+                [
+                  {
+                    "warningCode": "FailedToResolve",
+                    "affectedFiles": [
+                      "application\\build.gradle"
+                    ]
+                  }
+                ]
+        """
+        url = "/risk-management/risk-reports/{scanId}/warnings".format(scanId=scan_id)
+        response = self.api_client.get_request(relative_url=url)
+        return response.json()
+
     def ignore_a_vulnerability_for_a_specific_package_and_project(
             self, project_id: str, vulnerability_id: str, package_id: str
     ) -> bool:
@@ -2591,6 +2614,10 @@ def get_vulnerabilities_of_a_scan(scan_id):
 
 def get_licenses_of_a_scan(scan_id):
     return Sca().get_licenses_of_a_scan(scan_id=scan_id)
+
+
+def get_warnings_of_a_scan(scan_id):
+    return Sca().get_warnings_of_a_scan(scan_id=scan_id)
 
 
 def ignore_a_vulnerability_for_a_specific_package_and_project(project_id, vulnerability_id, package_id):

--- a/docs/CxSCA_REST_API_List.md
+++ b/docs/CxSCA_REST_API_List.md
@@ -19,6 +19,7 @@
     - get_packages_of_a_scan
     - get_vulnerabilities_of_a_scan
     - get_licenses_of_a_scan
+    - get_warnings_of_a_scan
     - ignore_a_vulnerability_for_a_specific_package_and_project
     - undo_the_ignore_state_of_an_ignored_vulnerability
     - get_scan_reports

--- a/tests/CxSCA/test_sca_api.py
+++ b/tests/CxSCA/test_sca_api.py
@@ -16,6 +16,7 @@ from CheckmarxPythonSDK.CxScaApiSDK import (
     get_packages_of_a_scan,
     get_vulnerabilities_of_a_scan,
     get_licenses_of_a_scan,
+    get_warnings_of_a_scan,
     ignore_a_vulnerability_for_a_specific_package_and_project,
     undo_the_ignore_state_of_an_ignored_vulnerability,
     get_settings_for_a_specific_project,
@@ -173,6 +174,21 @@ def test_get_licenses_of_a_scan():
     scan_id = get_latest_scan_id_of_a_project(project_id=project_id)
     licenses = get_licenses_of_a_scan(scan_id=scan_id)
     assert len(licenses) > 0
+
+
+def test_get_warnings_of_a_scan():
+    # No warnings
+    project_id = get_project_id_by_name(project_name)
+    scan_id = get_latest_scan_id_of_a_project(project_id=project_id)
+    warnings = get_warnings_of_a_scan(scan_id=scan_id)
+    assert len(warnings) == 0
+
+    # One warning
+    other_project_name = 'build-master'
+    project_id = get_project_id_by_name(other_project_name)
+    scan_id = get_latest_scan_id_of_a_project(project_id=project_id)
+    warnings = get_warnings_of_a_scan(scan_id=scan_id)
+    assert len(warnings) == 1
 
 
 def test_ignore_a_vulnerability_for_a_specific_package_and_project():


### PR DESCRIPTION
This PR adds the `get_warnings_of_a_scan` method to the `Sca` class (and a corresponding function to the `CxScaApiSDK` module.