### PR TITLE
Fix Scanner DTO: Rename fields to match API conventions

### DIFF
--- a/CheckmarxPythonSDK/CxOne/dto/Scanner.py
+++ b/CheckmarxPythonSDK/CxOne/dto/Scanner.py
@@ -8,20 +8,20 @@ class Scanner:
     Args:
         type (str): The type of scanner to run.
                 Allowed values: sast sca kics apisec containers
-        auto_pr_enabled (bool): If true, Checkmarx will automatically send suggested remediation actions.
+        enable_auto_pull_requests (bool): If true, Checkmarx will automatically send suggested remediation actions.
                     Note: Relevant only for sca scanner.
-        incremental (bool): If true, an incremental scan will be run by default (unless extensive changes are
+        incremental_scan (bool): If true, an incremental scan will be run by default (unless extensive changes are
             identified in the project). Note: Relevant only for sast scans.
     """
 
     type: str = None
-    auto_pr_enabled: bool = None
-    incremental: bool = None
+    enable_auto_pull_requests: bool = None
+    incremental_scan: bool = None
 
     def to_dict(self):
         result = {"type": self.type}
-        if self.auto_pr_enabled is not None:
-            result.update({"autoPrEnabled": self.auto_pr_enabled})
-        if self.incremental is not None:
-            result.update({"incremental": self.incremental})
+        if self.enable_auto_pull_requests is not None:
+            result.update({"enableAutoPullRequests": self.enable_auto_pull_requests})
+        if self.incremental_scan is not None:
+            result.update({"incrementalScan": self.incremental_scan})
         return result

--- a/tests/CxOne/test_code_repository_project_api.py
+++ b/tests/CxOne/test_code_repository_project_api.py
@@ -23,8 +23,8 @@ def test_import_code_repository():
             web_hook_enabled=False,
             decorate_pull_requests=False,
             scanners=[
-                Scanner(type="sast", incremental=False),
-                Scanner(type="sca", auto_pr_enabled=False),
+                Scanner(type="sast", incremental_scan=False),
+                Scanner(type="sca", enable_auto_pull_requests=False),
                 Scanner(type="apisec"),
                 Scanner(type="kics"),
             ]


### PR DESCRIPTION
  ## Summary
  Renamed Scanner DTO fields for better clarity and API consistency.

  - `autoPrEnabled` → `enableAutoPullRequests`
  - `incremental` → `incrementalScan`

>[!NOTE]  
The official CxOne API documentation needs to be updated as the documented field names do not match the actual parameters accepted by the API endpoints.
https://checkmarx.stoplight.io/docs/checkmarx-one-api-reference-guide/5yefdw9pm675i-import-code-repository

---
<img width="1429" height="1055" alt="image" src="https://github.com/user-attachments/assets/e051d719-5d24-42e6-af0f-b1504da74dfa" />
