### PR TITLE
[Add] scm_managed_project_scan to RepoManagerAPI

### DIFF
--- a/CheckmarxPythonSDK/CxOne/__init__.py
+++ b/CheckmarxPythonSDK/CxOne/__init__.py
@@ -227,6 +227,7 @@ from .repoManagerAPI import (
     batch_import_repo,
     get_repo_by_id,
     update_repo_by_id,
+    scm_managed_project_scan,
 )
 from .reportAPI import (
     ReportAPI,

--- a/CheckmarxPythonSDK/CxOne/repoManagerAPI.py
+++ b/CheckmarxPythonSDK/CxOne/repoManagerAPI.py
@@ -826,6 +826,111 @@ class RepoManagerAPI(object):
         response = self.api_client.call_api(method="GET", url=url)
         return response.json()
 
+    def scm_managed_project_scan(
+        self,
+        project_id: str,
+        origin: str,
+        organization: str,
+        repo_id: int,
+        repo_identity: str,
+        repo_url: str,
+        default_branch: str,
+        scanner_types: List[str] = None,
+        is_incremental_scan: bool = False,
+        org_ssh_key: str = None,
+    ) -> Response:
+        """Trigger a new scan for an existing CxOne project via its registered
+        SCM connection.
+
+        This wraps the repos-manager projectScan endpoint
+        (``POST /api/repos-manager/scms/{scm_id}/orgs/{organization}/repo/projectScan``),
+        which is distinct from ``create_scan`` from ``scansAPI``:
+
+        * ``create_scan`` requires the caller to supply source material
+          (file path, zip, or git URL) and is used for ad-hoc / standalone
+          scans.
+        * ``scm_managed_project_scan`` instructs CxOne to pull source from
+          the SCM connection already registered for the project; it's the
+          right entry point when automating "rescan an existing project on
+          its primary branch."
+
+        Args:
+            project_id (str): CxOne project UUID.
+            origin (str): SCM origin, one of GITHUB, GITLAB, AZURE, BITBUCKET.
+            organization (str): SCM organization slug (the org under which
+                the repo lives within the SCM).
+            repo_id (int): CxOne-internal repo ID. Available from project
+                metadata under ``repoId``.
+            repo_identity (str): SCM-side repo identifier. Available from
+                project metadata under ``scmRepoId``.
+            repo_url (str): Repository URL.
+            default_branch (str): Branch to scan (typically the project's
+                ``mainBranch``).
+            scanner_types (List[str]): Engines to run. Defaults to the full
+                set: ``["sast", "sca", "kics", "apisec", "containers", "2ms"]``.
+            is_incremental_scan (bool): Request incremental SAST. Defaults
+                to False (full scan).
+            org_ssh_key (str): Optional SSH key for the SCM connection.
+                Defaults to None.
+
+        Returns:
+            Response: HTTP response from the projectScan endpoint. CxOne
+            typically returns 2xx with an empty body on accept; the scan
+            shows up shortly after in ``get_a_list_of_scans``.
+
+        Raises:
+            ValueError: If ``origin`` is not a supported SCM type.
+
+        Example::
+
+            from CheckmarxPythonSDK.CxOne import (
+                RepoManagerAPI, get_a_project_by_id,
+            )
+            project = get_a_project_by_id(project_id="<uuid>")
+            RepoManagerAPI().scm_managed_project_scan(
+                project_id=project["id"],
+                origin=project["origin"],
+                organization="<scm-org-slug>",
+                repo_id=project["repoId"],
+                repo_identity=project["scmRepoId"],
+                repo_url=project["repoUrl"],
+                default_branch=project["mainBranch"],
+            )
+        """
+        scm_id = self.origin_dict.get(origin.upper())
+        if scm_id is None:
+            raise ValueError(
+                f"Unsupported origin '{origin}'. "
+                f"Supported: {list(self.origin_dict.keys())}"
+            )
+        if scanner_types is None:
+            scanner_types = [
+                "sast", "sca", "kics", "apisec", "containers", "2ms",
+            ]
+
+        url = (
+            f"{self.base_url}/{scm_id}/orgs/{organization}"
+            f"/repo/projectScan"
+        )
+        params = {"projectId": project_id}
+        payload = {
+            "repoOrigin": origin.lower(),
+            "project": {
+                "repoIdentity": str(repo_identity),
+                "repoUrl": repo_url,
+                "projectId": project_id,
+                "defaultBranch": default_branch,
+                "scannerTypes": scanner_types,
+                "repoId": str(repo_id),
+                "isIncrementalScan": is_incremental_scan,
+            },
+            "orgSshKey": org_ssh_key,
+        }
+        response = self.api_client.call_api(
+            method="POST", url=url, params=params, json=payload
+        )
+        return response
+
     def update_repo_by_id(self, repo_id: int, project_id: str, pay_load: dict) -> dict:
         """
 
@@ -1077,4 +1182,30 @@ def get_repo_by_id(repo_id: int) -> dict:
 def update_repo_by_id(repo_id: int, project_id: str, pay_load: dict) -> dict:
     return RepoManagerAPI().update_repo_by_id(
         repo_id=repo_id, project_id=project_id, pay_load=pay_load
+    )
+
+
+def scm_managed_project_scan(
+    project_id: str,
+    origin: str,
+    organization: str,
+    repo_id: int,
+    repo_identity: str,
+    repo_url: str,
+    default_branch: str,
+    scanner_types: List[str] = None,
+    is_incremental_scan: bool = False,
+    org_ssh_key: str = None,
+) -> Response:
+    return RepoManagerAPI().scm_managed_project_scan(
+        project_id=project_id,
+        origin=origin,
+        organization=organization,
+        repo_id=repo_id,
+        repo_identity=repo_identity,
+        repo_url=repo_url,
+        default_branch=default_branch,
+        scanner_types=scanner_types,
+        is_incremental_scan=is_incremental_scan,
+        org_ssh_key=org_ssh_key,
     )

--- a/tests/CxOne/test_repo_manager_api.py
+++ b/tests/CxOne/test_repo_manager_api.py
@@ -10,6 +10,8 @@ from CheckmarxPythonSDK.CxOne import (
     batch_import_repo,
     get_repo_by_id,
     update_repo_by_id,
+    scm_managed_project_scan,
+    get_a_project_by_id,
 )
 
 
@@ -245,3 +247,32 @@ def test_update_repo_by_id():
                                }
                                )
     assert result is not None
+
+
+def test_scm_managed_project_scan():
+    """Trigger a fresh scan on an existing project via its SCM connection.
+
+    Pulls the project's repo metadata first (repoId, scmRepoId, repoUrl,
+    mainBranch, origin) so the caller doesn't need to know them upfront.
+    The scan is queued; verify by looking at the response status and by
+    checking that a new scan appears in the project's scan list within a
+    minute or two.
+    """
+    project_id = os.getenv("SCM_SCAN_PROJECT_ID")
+    organization = os.getenv("SCM_SCAN_ORGANIZATION")
+    if not project_id or not organization:
+        import pytest
+        pytest.skip(
+            "set SCM_SCAN_PROJECT_ID and SCM_SCAN_ORGANIZATION to run"
+        )
+    project = get_a_project_by_id(project_id=project_id)
+    response = scm_managed_project_scan(
+        project_id=project["id"],
+        origin=project["origin"],
+        organization=organization,
+        repo_id=project["repoId"],
+        repo_identity=project["scmRepoId"],
+        repo_url=project["repoUrl"],
+        default_branch=project["mainBranch"],
+    )
+    assert response.status_code < 400


### PR DESCRIPTION
## Summary

Adds `scm_managed_project_scan` to `RepoManagerAPI`, wrapping the repos-manager `projectScan` endpoint (`POST /api/repos-manager/scms/{scm_id}/orgs/{organization}/repo/projectScan`). This endpoint triggers a fresh scan for an existing CxOne project via its already-registered SCM connection — distinct from `create_scan` in `scansAPI`, which requires the caller to ship source material.

Use case: triage / sync pipelines that automate "rescan an existing project on its primary branch" don't have local source on hand; they need CxOne to pull from the registered SCM. The endpoint exists and is exercised by the CxOne UI when a user clicks "Run Scan" on a project, but it wasn't wrapped in the SDK until now.

## Changes

- `CheckmarxPythonSDK/CxOne/repoManagerAPI.py`
  - New `RepoManagerAPI.scm_managed_project_scan()` method
  - Module-level `scm_managed_project_scan()` convenience wrapper
- `CheckmarxPythonSDK/CxOne/__init__.py`
  - Re-export `scm_managed_project_scan`
- `tests/CxOne/test_repo_manager_api.py`
  - Integration test gated on `SCM_SCAN_PROJECT_ID` + `SCM_SCAN_ORGANIZATION` env vars; skips automatically when not set

## Function signature

```python
RepoManagerAPI().scm_managed_project_scan(
    project_id: str,
    origin: str,                      # GITHUB / GITLAB / AZURE / BITBUCKET
    organization: str,                # SCM org slug under which the repo lives
    repo_id: int,                     # from project metadata: repoId
    repo_identity: str,               # from project metadata: scmRepoId
    repo_url: str,
    default_branch: str,              # typically project's mainBranch
    scanner_types: List[str] = None,  # defaults to all 6 engines
    is_incremental_scan: bool = False,
    org_ssh_key: str = None,
) -> Response
```

The `origin` parameter is validated against the existing `origin_dict` (GITHUB/GITLAB/AZURE/BITBUCKET) and raises `ValueError` for unsupported values. `scanner_types` defaults to the full set if omitted: `["sast", "sca", "kics", "apisec", "containers", "2ms"]`.

## Empirical verification

Tested against a real CxOne tenant (Archer-Technologies, GitLab origin). The POST returns 2xx (empty body), and the scan appears in `get_a_list_of_scans` within ~5 seconds with the new scan UUID, status=Running, and the expected branch / engines. Scan completes in normal time (~4 min for our test project; comparable to UI-triggered scans).

## Test plan

- [x] Method added on `RepoManagerAPI` class
- [x] Module-level convenience wrapper added
- [x] Re-exported from `CheckmarxPythonSDK.CxOne`
- [x] Integration test added (skips when env vars not set)
- [x] `python3 -m py_compile` clean on all three files
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)