### PR TITLE
fix: resolve url parameter shadowing in git source settings methods

### DIFF
--- a/CheckmarxPythonSDK/CxRestAPISDK/ProjectsAPI.py
+++ b/CheckmarxPythonSDK/CxRestAPISDK/ProjectsAPI.py
@@ -586,7 +586,7 @@ class ProjectsAPI(object):
                 "'none', 'credentials', 'PAT', 'ssh'] "
             )
 
-        url = f"{self.base_url}/cxrestapi/projects/{project_id}/sourceCode/remoteSettings/git"
+        api_url = f"{self.base_url}/cxrestapi/projects/{project_id}/sourceCode/remoteSettings/git"
         post_data = json.dumps(
             {
                 "url": url,
@@ -599,7 +599,7 @@ class ProjectsAPI(object):
             }
         )
         response = self.api_client.call_api(
-            "POST", url, data=post_data, headers=get_headers(api_version)
+            "POST", api_url, data=post_data, headers=get_headers(api_version)
         )
         return response.status_code == NO_CONTENT
 
@@ -1003,13 +1003,13 @@ class ProjectsAPI(object):
             NotFoundError
             CxError
         """
-        url = f"{self.base_url}/cxrestapi/projects/{project_id}/sourceCode/remoteSettings/git/ssh"
+        api_url = f"{self.base_url}/cxrestapi/projects/{project_id}/sourceCode/remoteSettings/git/ssh"
         file_name = os.path.basename(private_key_file_path)
         with open(private_key_file_path, "rb") as a_file:
             file_content = a_file.read()
         response = self.api_client.call_api(
             "POST",
-            url,
+            api_url,
             data={"url": url, "branch": branch},
             files={"privateKey": (file_name, file_content, "text/plain")},
             headers=get_headers(api_version),


### PR DESCRIPTION
# Fixes #197

## Summary

Resolves variable shadowing bug in `set_remote_source_setting_to_git` and `set_remote_source_setting_to_git_using_ssh` where the `url` parameter (git repository URL) is overwritten by the API endpoint URL before being used in the request body.

## Changes

- Renamed local variable `url` to `api_url` in both methods to avoid shadowing the function parameter.


## Before (broken)

```python
url = f"{self.base_url}/cxrestapi/projects/{project_id}/sourceCode/remoteSettings/git"
post_data = json.dumps({"url": url, ...})  # sends endpoint URL, not git repo URL
response = self.api_client.call_api("POST", url, ...)
```

## After (fixed)

```python
api_url = f"{self.base_url}/cxrestapi/projects/{project_id}/sourceCode/remoteSettings/git"
post_data = json.dumps({"url": url, ...})  # correctly sends git repo URL
response = self.api_client.call_api("POST", api_url, ...)
```

## Testing

```python
from CheckmarxPythonSDK.CxRestAPISDK import ProjectsAPI
from unittest.mock import MagicMock

api_client = MagicMock()
p = ProjectsAPI(api_client=api_client)
p.base_url = "https://sast.example.com"
api_client.call_api = MagicMock(return_value=MagicMock(status_code=204))


p.set_remote_source_setting_to_git(
    project_id=123,
    url="https://git.example.com/repo.git",
    branch="refs/heads/main"
)

call_args = api_client.call_api.call_args
# Before fix: data contains "https://sast.example.com/cxrestapi/projects/123/..."
# After fix:  data contains "https://git.example.com/repo.git"
assert "git.example.com/repo.git" in call_args.kwargs.get("data", call_args[1][2] if len(call_args[1]) > 2 else "")
```
