### PR TITLE
Fix the get_application_id_by_name method

### DIFF
--- a/CheckmarxPythonSDK/CxOne/applicationsAPI.py
+++ b/CheckmarxPythonSDK/CxOne/applicationsAPI.py
@@ -85,7 +85,9 @@ class ApplicationsAPI(object):
         app_collection = self.get_a_list_of_applications(name=name)
         applications = app_collection.applications
         if applications:
-            return applications[0].id
+            for application in applications:
+                if application.name == name:
+                    return application.id
         return None
 
     def get_all_application_tags(self) -> dict:


### PR DESCRIPTION
Previously, this method returned the identifier of the first application returned by a call to the `get_a_list_of_applications` method. However, the first application might not be the one that the caller is interested in. The method now iterates over the applications returned by the call to `get_a_list_of_applications` until it finds an exact match.