### PR TITLE
Fix get_scan_report_status field names

### DIFF
--- a/CheckmarxPythonSDK/CxPortalSoapApiSDK/CxPortalWebService.py
+++ b/CheckmarxPythonSDK/CxPortalSoapApiSDK/CxPortalWebService.py
@@ -1452,7 +1452,8 @@ class CxPortalWebService(object):
         return {
             "IsSuccesfull": response["IsSuccesfull"],
             "ErrorMessage": getattr(response, "ErrorMessage", None),
-            "Status": getattr(response, "Status", None),
+            "IsReady": getattr(response, "IsReady", None),
+            "IsFailed": getattr(response, "IsFailed", None),
         }
 
     def cancel_scan_report(self, report_id: int) -> dict:

--- a/tests/CxSAST/CxPortalSOAP/test_cx_portal_web_service.py
+++ b/tests/CxSAST/CxPortalSOAP/test_cx_portal_web_service.py
@@ -448,6 +448,12 @@ def test_get_scan_report_and_status():
 
     status_response = get_scan_report_status(report_id=report_id)
     assert status_response["IsSuccesfull"] is True
+    # SOAP response exposes IsReady/IsFailed booleans (not the "Status"
+    # field the doc-derived stub previously returned as always-None).
+    assert "IsReady" in status_response
+    assert "IsFailed" in status_response
+    assert isinstance(status_response["IsReady"], bool)
+    assert isinstance(status_response["IsFailed"], bool)
 
     cancel_response = cancel_scan_report(report_id=report_id)
     assert cancel_response["IsSuccesfull"] is True


### PR DESCRIPTION
The CxPortal SOAP GetScanReportStatus response has no `Status` field — the returned dict's `Status` key was always None. The real fields are `IsReady` and `IsFailed` (both booleans). Return those instead.

Test upgrade: the existing assertion only checked IsSuccesfull, so it never caught the always-None `Status`. Assert that IsReady and IsFailed are both present and are bool — the previous code would fail this because it never populated those keys.

Verified against the live SAST server (test passes in ~2s).