### PR TITLE
Advertise Python 3.13 and 3.14 support in setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
The classifiers stopped at 3.12 while python_requires='>=3.9' already covers 3.13/3.14 and the SDK runs fine on both (the local dev env uses 3.14). Add the missing classifiers so PyPI reflects reality.