### PR TITLE
Refactor sast_high_level_report example to use ScansODataAPI

### DIFF
--- a/examples/CxSAST/sast_high_level_report.py
+++ b/examples/CxSAST/sast_high_level_report.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import sys
 
-from CheckmarxPythonSDK.CxODataApiSDK.HttpRequests import get_request
+from CheckmarxPythonSDK.CxODataApiSDK import ScansODataAPI
 from CheckmarxPythonSDK.CxPortalSoapApiSDK import get_compare_scan_results
 from CheckmarxPythonSDK.CxRestAPISDK import AccessControlAPI
 from CheckmarxPythonSDK.CxRestAPISDK import CustomFieldsAPI
@@ -16,6 +16,7 @@ from CheckmarxPythonSDK.CxRestAPISDK import ProjectsAPI
 access_control_api = AccessControlAPI()
 custom_fields_api = CustomFieldsAPI()
 projects_api = ProjectsAPI()
+_scans_api = ScansODataAPI()
 
 
 class Summary:
@@ -96,7 +97,8 @@ def get_all_scans_in_date_range(args):
     )
 
     logging.debug(f"url: {url}")
-    return get_request(relative_url=url)
+    response = _scans_api.api_client.call_api(method="GET", url=f"{_scans_api.base_url}{url}")
+    return response.json().get("value")
 
 
 def get_scan_with_results(scan_id):
@@ -106,7 +108,8 @@ def get_scan_with_results(scan_id):
     )
 
     logging.debug(f"url: {url}")
-    scan = get_request(relative_url=url)[0]
+    response = _scans_api.api_client.call_api(method="GET", url=f"{_scans_api.base_url}{url}")
+    scan = response.json().get("value")[0]
     logging.debug(
         f'scan: id={scan["Id"]}'
         f',project_name={scan["ProjectName"]}'


### PR DESCRIPTION
## Summary

- Replace deleted `CxODataApiSDK.HttpRequests.get_request` import with `ScansODataAPI` from `CxODataApiSDK`
- Add module-level `_scans_api = ScansODataAPI()` instance alongside the existing API instances
- Replace both `get_request(relative_url=url)` calls with `_scans_api.api_client.call_api(method="GET", url=f"{_scans_api.base_url}{url}").json().get("value")`, consistent with all other `ScansODataAPI` methods

## Test plan

- [ ] Verify `examples/CxSAST/sast_high_level_report.py` imports without error
- [ ] Run the script against a CxSAST instance to confirm scan listing and result expansion still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)