### PR TITLE
Remove legacy HTTP method wrappers from ApiClient

### DIFF
--- a/CheckmarxPythonSDK/api_client.py
+++ b/CheckmarxPythonSDK/api_client.py
@@ -271,20 +271,3 @@ class ApiClient:
         check_response(response)
         return response
 
-    def head_request(self, url, auth=None, headers=None, json=None, params=None):
-        return self.call_api(method="HEAD", url=url, auth=auth, headers=headers, json=json, params=params)
-
-    def get_request(self, url, auth=None, headers=None, params=None):
-        return self.call_api(method="GET", url=url, auth=auth, headers=headers, params=params)
-
-    def post_request(self, url, data=None, files=None, auth=None, headers=None, params=None, json=None):
-        return self.call_api(method="POST", url=url, data=data, files=files, auth=auth, headers=headers, params=params, json=json)
-
-    def put_request(self, url, data=None, files=None, auth=None, headers=None, params=None, json=None):
-        return self.call_api(method="PUT", url=url, data=data, files=files, auth=auth, headers=headers, params=params, json=json)
-
-    def patch_request(self, url, data=None, auth=None, headers=None, params=None, json=None):
-        return self.call_api(method="PATCH", url=url, data=data, auth=auth, headers=headers, params=params, json=json)
-
-    def delete_request(self, url, data=None, auth=None, headers=None, params=None, json=None):
-        return self.call_api(method="DELETE", url=url, data=data, auth=auth, headers=headers, params=params, json=json)


### PR DESCRIPTION
## Summary

- Remove `head_request`, `get_request`, `post_request`, `put_request`, `patch_request`, and `delete_request` from `ApiClient`
- All six were thin one-liner wrappers around `call_api` with no remaining callers — the entire SDK (CxOne, CxRestAPISDK, CxScaApiSDK, CxAccessControl, CxReporting, CxODataApiSDK) has been fully migrated to `call_api`
- Verified with `grep` that no code in the SDK, tests, or examples references these methods

## Test plan

- [ ] Run the full test suite to confirm no regressions
- [ ] Grep for `\.get_request\|\.post_request\|\.put_request\|\.patch_request\|\.delete_request\|\.head_request` to confirm zero remaining usages

🤖 Generated with [Claude Code](https://claude.com/claude-code)