### PR TITLE
Fix: handle multiple filter parameter values correctly

### DIFF
--- a/CheckmarxPythonSDK/CxOne/scannersResultsAPI.py
+++ b/CheckmarxPythonSDK/CxOne/scannersResultsAPI.py
@@ -44,6 +44,16 @@ class ScannersResultsAPI(object):
         Returns:
             dict
         """
+
+        # The endpoint expects the severity, state and status values
+        # to be passed as comma-separated strings.
+        if severity:
+            severity = ','.join(severity)
+        if state:
+            state = ','.join(state)
+        if status:
+            status = ','.join(status)
+
         params = {
             "scan-id": scan_id,
             "severity": severity,


### PR DESCRIPTION
The `GET /api/results endpoint` expects that multiple parameter values be provided as a comma-separated list. For example:
```
state=CONFIRMED,URGENT
```

This is different to other API endpoints (e.g. `GET /api/scans`) where multiple values require that the same query parameter be provided multiple times.