### PR TITLE
Add script to disable Exploitable Path for all projects in tenant

### DIFF
--- a/examples/CxOne/disable_exploitable_path_for_all_projects.py
+++ b/examples/CxOne/disable_exploitable_path_for_all_projects.py
@@ -1,0 +1,181 @@
+"""
+Disable the 'Exploitable Path' SCA setting for every project in the tenant.
+
+For each project, the current value of the "scan.config.sca.ExploitablePath"
+scan parameter is read. Projects that already have it disabled are skipped;
+all others are updated to set the parameter to "false" at the Project level.
+
+By default the script only prints what it *would* change (dry run). Pass
+--apply to actually make the change, and --yes to skip the confirmation
+prompt (e.g. for unattended/CI runs).
+
+Secrets are read from a .env file in the project root.
+
+Usage:
+    python disable_exploitable_path_for_all_projects.py [--apply] [--yes]
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from CheckmarxPythonSDK.configuration import Configuration
+from CheckmarxPythonSDK.api_client import ApiClient
+from CheckmarxPythonSDK.CxOne.projectsAPI import ProjectsAPI
+from CheckmarxPythonSDK.CxOne.scanConfigurationAPI import ScanConfigurationAPI
+from CheckmarxPythonSDK.CxOne.dto.ScanParameter import ScanParameter
+
+EXPLOITABLE_PATH_KEY = "scan.config.sca.ExploitablePath"
+
+
+def load_dotenv():
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if not env_path.exists():
+        print(f"Warning: {env_path} not found, using environment variables.")
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip("\"'")
+            os.environ[key] = value
+
+
+def build_configuration() -> Configuration:
+    load_dotenv()
+    tenant_name = os.environ["CXONE_TENANT_NAME"]
+    access_control_url = os.environ.get(
+        "CXONE_IAM_URL", "https://sng.iam.checkmarx.net"
+    )
+    server_base_url = os.environ.get(
+        "CXONE_SERVER_URL", "https://sng.ast.checkmarx.net"
+    )
+    grant_type = os.environ.get("CXONE_GRANT_TYPE", "refresh_token")
+    client_id = os.environ.get("CXONE_CLIENT_ID", "ast-app")
+    client_secret = os.environ.get("CXONE_CLIENT_SECRET")
+    refresh_token = os.environ.get("CXONE_REFRESH_TOKEN")
+    if not refresh_token:
+        grant_type = "client_credentials"
+    return Configuration(
+        server_base_url=server_base_url,
+        iam_base_url=access_control_url,
+        token_url=(
+            f"{access_control_url}/auth/realms"
+            f"/{tenant_name}/protocol/openid-connect/token"
+        ),
+        tenant_name=tenant_name,
+        grant_type=grant_type,
+        client_id=client_id,
+        client_secret=client_secret,
+        api_key=refresh_token,
+    )
+
+
+def get_exploitable_path_value(scan_config_api: ScanConfigurationAPI, project_id: str):
+    """Return the current value (str) of the ExploitablePath parameter for a
+    project, or None if it is not explicitly set at the project level."""
+    parameters = scan_config_api.get_the_list_of_all_the_parameters_for_a_project(
+        project_id=project_id
+    )
+    for parameter in parameters:
+        if parameter.key == EXPLOITABLE_PATH_KEY:
+            return parameter.value
+    return None
+
+
+def disable_exploitable_path(scan_config_api: ScanConfigurationAPI, project_id: str) -> bool:
+    """Set the ExploitablePath parameter to "false" at the Project level."""
+    scan_parameter = ScanParameter(
+        key=EXPLOITABLE_PATH_KEY,
+        name="exploitablePath",
+        category="sca",
+        originLevel="Project",
+        value="false",
+        valueType="Bool",
+        valueTypeParams=None,
+        allowOverride=True,
+    )
+    return scan_config_api.define_parameters_in_the_input_list_for_a_specific_project(
+        project_id=project_id, scan_parameters=[scan_parameter]
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Disable 'Exploitable Path' for every project in the tenant."
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually apply the change. Without this flag, only a dry run "
+             "(preview) is performed.",
+    )
+    parser.add_argument(
+        "--yes", action="store_true",
+        help="Skip the confirmation prompt (only relevant with --apply).",
+    )
+    args = parser.parse_args()
+
+    configuration = build_configuration()
+    api_client = ApiClient(configuration=configuration)
+
+    projects_api = ProjectsAPI(api_client=api_client)
+    scan_config_api = ScanConfigurationAPI(api_client=api_client)
+
+    all_projects = projects_api.get_all_projects()
+    print(f"Found {len(all_projects)} projects.")
+
+    to_update = []
+    already_disabled = 0
+    for project in all_projects:
+        current_value = get_exploitable_path_value(scan_config_api, project.id)
+        if current_value is not None and current_value.lower() == "false":
+            already_disabled += 1
+            continue
+        to_update.append((project, current_value))
+
+    print(f"Already disabled: {already_disabled}")
+    print(f"To be disabled:   {len(to_update)}")
+    for project, current_value in to_update:
+        shown = current_value if current_value is not None else "(inherited/unset)"
+        print(f"  - {project.name} ({project.id}): current value = {shown}")
+
+    if not to_update:
+        print("\nNothing to do.")
+        return
+
+    if not args.apply:
+        print("\nDry run only, no changes made. Re-run with --apply to make changes.")
+        return
+
+    if not args.yes:
+        answer = input(
+            f"\nAbout to disable 'Exploitable Path' for {len(to_update)} "
+            f"project(s). Continue? [y/N] "
+        )
+        if answer.strip().lower() != "y":
+            print("Aborted.")
+            return
+
+    succeeded = 0
+    failed = []
+    for i, (project, _) in enumerate(to_update, 1):
+        print(f"  [{i}/{len(to_update)}] {project.name} ...", end=" ", flush=True)
+        is_successful = disable_exploitable_path(scan_config_api, project.id)
+        print("OK" if is_successful else "FAILED")
+        if is_successful:
+            succeeded += 1
+        else:
+            failed.append(project.name)
+
+    print(f"\nDisabled 'Exploitable Path' for {succeeded}/{len(to_update)} projects.")
+    if failed:
+        print("Failed projects:")
+        for name in failed:
+            print(f"  - {name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `examples/CxOne/disable_exploitable_path_for_all_projects.py`, which iterates every project in the tenant and disables the SCA "Exploitable Path" setting (`scan.config.sca.ExploitablePath`) via `ScanConfigurationAPI`.
- Defaults to a dry run (prints what would change); `--apply` performs the change, `--yes` skips the confirmation prompt.
- Follows the same structure as `examples/CxOne/export_sast_state_by_query.py` (`.env` loading, `build_configuration()`, progress printing).

## Testing
Tested against a live CxOne tenant:
- Dry run found 20 projects (3 already disabled, 17 to update).
- `--apply` succeeded for all 17.
- Follow-up dry run confirmed all 20 projects now report Exploitable Path disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)